### PR TITLE
Handle profile load timeouts

### DIFF
--- a/lib/services/backend_api_service.dart
+++ b/lib/services/backend_api_service.dart
@@ -8,7 +8,7 @@ import 'env_service.dart';
 class BackendApiService {
   BackendApiService({
     http.Client? client,
-    this.timeoutTime = const Duration(seconds: 15),
+    this.timeoutTime = const Duration(seconds: 30),
   }) : _client = client ?? http.Client();
 
   final Duration timeoutTime;

--- a/lib/ui/views/profile/profile_viewmodel.dart
+++ b/lib/ui/views/profile/profile_viewmodel.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
+import 'package:stacked_services/stacked_services.dart';
 import 'package:wpgg/app/app.locator.dart';
 import 'package:wpgg/models/profile_account.dto.dart';
 import 'package:wpgg/models/match_summary.dto.dart';
@@ -7,6 +9,7 @@ import 'package:wpgg/models/stats.dto.dart';
 import 'package:wpgg/models/gameplay_recommendation.dto.dart';
 import 'package:wpgg/services/riot_api_service.dart';
 import 'package:wpgg/services/secure_storage_service.dart';
+import 'package:wpgg/ui/common/widgets/snackbar_bar.dart';
 
 class ProfileViewModel extends BaseViewModel {
   final _riot = locator<RiotApiService>();
@@ -20,16 +23,26 @@ class ProfileViewModel extends BaseViewModel {
 
   Future<void> loadData() async {
     setBusy(true);
-    final puuid = await _secure.read('last_puuid');
-    if (puuid != null) {
-      profile = await _riot.fetchProfileAccount(puuid);
-      matches = await _riot.fetchMatches(puuid);
-      ranks = await _riot.fetchRanks(puuid);
-      stats = await _riot.fetchStats(puuid);
-      if (stats != null) {
-        recommendation = await _riot.fetchRecommendation(stats!);
+    final _snackbar = locator<SnackbarService>();
+    try {
+      final puuid = await _secure.read('last_puuid');
+      if (puuid != null) {
+        profile = await _riot.fetchProfileAccount(puuid);
+        matches = await _riot.fetchMatches(puuid);
+        ranks = await _riot.fetchRanks(puuid);
+        stats = await _riot.fetchStats(puuid);
+        if (stats != null) {
+          recommendation = await _riot.fetchRecommendation(stats!);
+        }
       }
+    } catch (e) {
+      debugPrint('$e');
+      _snackbar.showCustomSnackBar(
+        variant: SnackbarType.error,
+        message: 'Error loading profile data',
+      );
+    } finally {
+      setBusy(false);
     }
-    setBusy(false);
   }
 }


### PR DESCRIPTION
## Summary
- show an error snackbar when profile data fails to load
- extend BackendApiService timeout to 30 seconds

