### PR TITLE
Fix startup route showing profile

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,7 @@ class MainApp extends StatelessWidget {
 
   Route<dynamic>? _generateRoute(RouteSettings settings) {
     final uri = Uri.parse(settings.name ?? '');
-    final match = RegExp(r'^/([^/]+)-([^/]+)/?$').firstMatch(uri.path);
+    final match = RegExp(r'^/profile/([^/]+)-([^/]+)/?$').firstMatch(uri.path);
     if (match != null) {
       return MaterialPageRoute(
         builder: (context) => const ProfileView(),

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -21,7 +21,7 @@ class HomeViewModel extends BaseViewModel {
         tagController.text,
       );
       await _secure.write('last_puuid', account.puuid);
-      await _nav.navigateTo('/${gameController.text}-${tagController.text}');
+      await _nav.navigateTo('/profile/${gameController.text}-${tagController.text}');
     } catch (e) {
       debugPrint('$e');
     } finally {


### PR DESCRIPTION
## Summary
- avoid regex match with `/startup-view` by only matching profile routes
- update profile navigation path
