### PR TITLE
Add runes display in match summary

### DIFF
--- a/lib/models/participant.dto.dart
+++ b/lib/models/participant.dto.dart
@@ -3,6 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'account.dto.dart';
 import 'summoner_spells.dto.dart';
 import 'build.dto.dart';
+import 'runes.dto.dart';
 
 part 'participant.dto.g.dart';
 
@@ -18,6 +19,7 @@ class ParticipantDTO {
     this.accountDto,
     this.summonerSpellsDto,
     this.buildDto,
+    this.runesDto,
   });
 
   String? championName;
@@ -30,6 +32,7 @@ class ParticipantDTO {
   AccountDTO? accountDto;
   SummonerSpellsDTO? summonerSpellsDto;
   BuildDTO? buildDto;
+  RunesDTO? runesDto;
 
   factory ParticipantDTO.fromJson(Map<String, dynamic> json) =>
       _$ParticipantDTOFromJson(json);

--- a/lib/models/participant.dto.g.dart
+++ b/lib/models/participant.dto.g.dart
@@ -24,6 +24,9 @@ ParticipantDTO _$ParticipantDTOFromJson(Map<String, dynamic> json) =>
       buildDto: json['buildDto'] == null
           ? null
           : BuildDTO.fromJson(json['buildDto'] as Map<String, dynamic>),
+      runesDto: json['runesDto'] == null
+          ? null
+          : RunesDTO.fromJson(json['runesDto'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$ParticipantDTOToJson(ParticipantDTO instance) =>
@@ -37,4 +40,5 @@ Map<String, dynamic> _$ParticipantDTOToJson(ParticipantDTO instance) =>
       'accountDto': instance.accountDto?.toJson(),
       'summonerSpellsDto': instance.summonerSpellsDto?.toJson(),
       'buildDto': instance.buildDto?.toJson(),
+      'runesDto': instance.runesDto?.toJson(),
     };

--- a/lib/models/runes.dto.dart
+++ b/lib/models/runes.dto.dart
@@ -1,0 +1,55 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'runes.dto.g.dart';
+
+@JsonSerializable()
+class RuneSelectionDTO {
+  RuneSelectionDTO({this.perk, this.var1, this.var2, this.var3});
+
+  int? perk;
+  int? var1;
+  int? var2;
+  int? var3;
+
+  factory RuneSelectionDTO.fromJson(Map<String, dynamic> json) =>
+      _$RuneSelectionDTOFromJson(json);
+  Map<String, dynamic> toJson() => _$RuneSelectionDTOToJson(this);
+}
+
+@JsonSerializable()
+class RuneStyleDTO {
+  RuneStyleDTO({this.description, this.selections, this.style});
+
+  String? description;
+  List<RuneSelectionDTO>? selections;
+  int? style;
+
+  factory RuneStyleDTO.fromJson(Map<String, dynamic> json) =>
+      _$RuneStyleDTOFromJson(json);
+  Map<String, dynamic> toJson() => _$RuneStyleDTOToJson(this);
+}
+
+@JsonSerializable()
+class RuneStatPerksDTO {
+  RuneStatPerksDTO({this.defense, this.flex, this.offense});
+
+  int? defense;
+  int? flex;
+  int? offense;
+
+  factory RuneStatPerksDTO.fromJson(Map<String, dynamic> json) =>
+      _$RuneStatPerksDTOFromJson(json);
+  Map<String, dynamic> toJson() => _$RuneStatPerksDTOToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class RunesDTO {
+  RunesDTO({this.statPerks, this.styles});
+
+  RuneStatPerksDTO? statPerks;
+  List<RuneStyleDTO>? styles;
+
+  factory RunesDTO.fromJson(Map<String, dynamic> json) =>
+      _$RunesDTOFromJson(json);
+  Map<String, dynamic> toJson() => _$RunesDTOToJson(this);
+}

--- a/lib/models/runes.dto.g.dart
+++ b/lib/models/runes.dto.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'runes.dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RuneSelectionDTO _$RuneSelectionDTOFromJson(Map<String, dynamic> json) =>
+    RuneSelectionDTO(
+      perk: (json['perk'] as num?)?.toInt(),
+      var1: (json['var1'] as num?)?.toInt(),
+      var2: (json['var2'] as num?)?.toInt(),
+      var3: (json['var3'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$RuneSelectionDTOToJson(RuneSelectionDTO instance) =>
+    <String, dynamic>{
+      'perk': instance.perk,
+      'var1': instance.var1,
+      'var2': instance.var2,
+      'var3': instance.var3,
+    };
+
+RuneStyleDTO _$RuneStyleDTOFromJson(Map<String, dynamic> json) => RuneStyleDTO(
+      description: json['description'] as String?,
+      selections: (json['selections'] as List<dynamic>?)
+          ?.map((e) => RuneSelectionDTO.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      style: (json['style'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$RuneStyleDTOToJson(RuneStyleDTO instance) =>
+    <String, dynamic>{
+      'description': instance.description,
+      'selections': instance.selections?.map((e) => e.toJson()).toList(),
+      'style': instance.style,
+    };
+
+RuneStatPerksDTO _$RuneStatPerksDTOFromJson(Map<String, dynamic> json) =>
+    RuneStatPerksDTO(
+      defense: (json['defense'] as num?)?.toInt(),
+      flex: (json['flex'] as num?)?.toInt(),
+      offense: (json['offense'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$RuneStatPerksDTOToJson(RuneStatPerksDTO instance) =>
+    <String, dynamic>{
+      'defense': instance.defense,
+      'flex': instance.flex,
+      'offense': instance.offense,
+    };
+
+RunesDTO _$RunesDTOFromJson(Map<String, dynamic> json) => RunesDTO(
+      statPerks: json['statPerks'] == null
+          ? null
+          : RuneStatPerksDTO.fromJson(
+              json['statPerks'] as Map<String, dynamic>),
+      styles: (json['styles'] as List<dynamic>?)
+          ?.map((e) => RuneStyleDTO.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$RunesDTOToJson(RunesDTO instance) =>
+    <String, dynamic>{
+      'statPerks': instance.statPerks?.toJson(),
+      'styles': instance.styles?.map((e) => e.toJson()).toList(),
+    };

--- a/lib/ui/common/widgets/match_summary_card.dart
+++ b/lib/ui/common/widgets/match_summary_card.dart
@@ -197,7 +197,11 @@ class _MatchSummaryCardState extends State<MatchSummaryCard> {
           Expanded(
             child: Center(
               child: Text(
-                'Runas N/A',
+                p.runesDto != null
+                    ? 'Runas: '
+                        '${p.runesDto!.styles?[0].selections?[0].perk ?? '-'} / '
+                        '${p.runesDto!.styles?.length > 1 ? p.runesDto!.styles?[1].selections?[0].perk : '-'}'
+                    : 'Runas N/A',
                 style: const TextStyle(fontSize: 12, color: Colors.grey),
               ),
             ),


### PR DESCRIPTION
## Summary
- add new RunesDTO model to parse rune information
- store runes data in ParticipantDTO
- show rune IDs in match summary cards
