### PR TITLE
Display rune icons with DDragon

### DIFF
--- a/lib/services/ddragon_service.dart
+++ b/lib/services/ddragon_service.dart
@@ -32,6 +32,8 @@ class DDragonService {
   String profileIcon(int id) => "${_baseUrl}/profileicon/${id}.png";
   String itemIcon(int id) => "${_baseUrl}/item/${id}.png";
 
+  String runeIcon(int id) => "${_baseUrl}/perk-images/${id}.png";
+
   static const Map<int, String> _spellMap = {
     21: 'SummonerBarrier',
     1: 'SummonerBoost',

--- a/lib/ui/common/widgets/match_summary_card.dart
+++ b/lib/ui/common/widgets/match_summary_card.dart
@@ -196,14 +196,39 @@ class _MatchSummaryCardState extends State<MatchSummaryCard> {
           ),
           Expanded(
             child: Center(
-              child: Text(
-                p.runesDto != null
-                    ? 'Runas: '
-                        '${p.runesDto!.styles?[0].selections?[0].perk ?? '-'} / '
-                        '${p.runesDto!.styles?.length > 1 ? p.runesDto!.styles?[1].selections?[0].perk : '-'}'
-                    : 'Runas N/A',
-                style: const TextStyle(fontSize: 12, color: Colors.grey),
-              ),
+              child: p.runesDto != null
+                  ? Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        if (p.runesDto!.styles?[0].selections?[0].perk != null)
+                          Image.network(
+                            ddragon.runeIcon(
+                                p.runesDto!.styles![0].selections![0].perk!),
+                            width: 20,
+                            height: 20,
+                            errorBuilder: (c, e, s) =>
+                                const SizedBox(width: 20, height: 20),
+                          ),
+                        if (p.runesDto!.styles?.length != null &&
+                            p.runesDto!.styles!.length > 1 &&
+                            p.runesDto!.styles![1].selections?[0].perk != null)
+                          ...[
+                            const SizedBox(width: 4),
+                            Image.network(
+                              ddragon.runeIcon(
+                                  p.runesDto!.styles![1].selections![0].perk!),
+                              width: 20,
+                              height: 20,
+                              errorBuilder: (c, e, s) =>
+                                  const SizedBox(width: 20, height: 20),
+                            ),
+                          ],
+                      ],
+                    )
+                  : const Text(
+                      'Runas N/A',
+                      style: TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
             ),
           ),
           Expanded(


### PR DESCRIPTION
## Summary
- add runeIcon to DDragonService
- show rune images in MatchSummaryCard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e83ee0458832cb08afb07a2f7f4dc