### PR TITLE
Improve loading animations and error handling

### DIFF
--- a/lib/ui/common/widgets/loading_widget.dart
+++ b/lib/ui/common/widgets/loading_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:wpgg/ui/common/widgets/wpgg_logo.dart';
 
 class LoadingWidget extends StatefulWidget {
@@ -12,13 +13,17 @@ class LoadingWidget extends StatefulWidget {
 class _LoadingWidgetState extends State<LoadingWidget>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
+  late final Animation<double> _scaleAnimation;
 
   @override
   void initState() {
     super.initState();
     _controller =
         AnimationController(vsync: this, duration: const Duration(seconds: 2))
-          ..repeat();
+          ..repeat(reverse: true);
+    _scaleAnimation = Tween<double>(begin: 0.8, end: 1.2).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
   }
 
   @override
@@ -29,20 +34,41 @@ class _LoadingWidgetState extends State<LoadingWidget>
 
   @override
   Widget build(BuildContext context) {
+    final progressColor =
+        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            RotationTransition(
-              turns: _controller,
+            ScaleTransition(
+              scale: _scaleAnimation,
               child: const WpggLogo(width: 150),
             ),
             const SizedBox(height: 16),
             SizedBox(
+              height: 20,
+              child: AnimatedTextKit(
+                repeatForever: true,
+                pause: const Duration(milliseconds: 300),
+                animatedTexts: [
+                  TypewriterAnimatedText(
+                    'Cargando... ',
+                    speed: const Duration(milliseconds: 100),
+                    textStyle: const TextStyle(fontSize: 16),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
               width: 200,
-              child: LinearProgressIndicator(value: widget.progress),
+              child: LinearProgressIndicator(
+                value: widget.progress,
+                color: progressColor,
+                backgroundColor: progressColor.withOpacity(0.3),
+              ),
             ),
           ],
         ),

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -1,9 +1,11 @@
 import 'package:stacked/stacked.dart';
 import 'package:flutter/material.dart';
+import 'dart:convert';
 import 'package:stacked_services/stacked_services.dart';
 import 'package:wpgg/app/app.locator.dart';
 import 'package:wpgg/services/riot_api_service.dart';
 import 'package:wpgg/services/secure_storage_service.dart';
+import 'package:wpgg/ui/common/widgets/snackbar_bar.dart';
 
 class HomeViewModel extends BaseViewModel {
   final gameController = TextEditingController();
@@ -12,6 +14,7 @@ class HomeViewModel extends BaseViewModel {
   final RiotApiService _riot = locator<RiotApiService>();
   final NavigationService _nav = locator<NavigationService>();
   final SecureStorageService _secure = locator<SecureStorageService>();
+  final SnackbarService _snackbar = locator<SnackbarService>();
 
   Future<void> search() async {
     setBusy(true);
@@ -25,6 +28,20 @@ class HomeViewModel extends BaseViewModel {
           .navigateTo('/profile/${gameController.text}-${tagController.text}');
     } catch (e) {
       debugPrint('$e');
+      var message = e.toString();
+      final match = RegExp(r'\{.*\}').firstMatch(message);
+      if (match != null) {
+        try {
+          final decoded = jsonDecode(match.group(0)!);
+          if (decoded is Map<String, dynamic> && decoded['error'] != null) {
+            message = decoded['error'] as String;
+          }
+        } catch (_) {}
+      }
+      _snackbar.showCustomSnackBar(
+        variant: SnackbarType.error,
+        message: message,
+      );
     } finally {
       setBusy(false);
     }

--- a/lib/ui/views/startup/startup_view.dart
+++ b/lib/ui/views/startup/startup_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:stacked/stacked.dart';
+import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:wpgg/ui/common/ui_helpers.dart';
 
 import 'startup_viewmodel.dart';
@@ -26,7 +27,20 @@ class StartupView extends StackedView<StartupViewModel> {
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text('Loading ...', style: TextStyle(fontSize: 16)),
+                SizedBox(
+                  height: 20,
+                  child: AnimatedTextKit(
+                    repeatForever: true,
+                    pause: const Duration(milliseconds: 300),
+                    animatedTexts: [
+                      TypewriterAnimatedText(
+                        'Cargando... ',
+                        speed: const Duration(milliseconds: 100),
+                        textStyle: const TextStyle(fontSize: 16),
+                      ),
+                    ],
+                  ),
+                ),
                 horizontalSpaceSmall,
                 SizedBox(
                   width: 16,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   json_annotation: ^4.9.0
   stacked: ^3.4.0
   stacked_services: ^1.1.0
+  animated_text_kit: ^4.2.2
 
 dev_dependencies:
   build_runner: ^2.4.5
@@ -32,5 +33,4 @@ flutter:
   # Incluye **todo** lo que esté dentro de assets/
   assets:
     - env    
-    - assets/
-    - lib/models/runesReforged.json
+    - assets/    - lib/models/runesReforged.json


### PR DESCRIPTION
## Summary
- add `animated_text_kit` dependency
- show typed text and pulsing logo while loading
- adapt progress bar color for light/dark themes
- display backend error in snackbar when search fails

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ed97a7388832c86d83d86e8ca2180