### PR TITLE
Implement champion global stats search

### DIFF
--- a/lib/models/champion_global_stats.dto.dart
+++ b/lib/models/champion_global_stats.dto.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'build.dto.dart';
+import 'runes.dto.dart';
+import 'summoner_spells.dto.dart';
+import 'role_stats.dto.dart';
+
+part 'champion_global_stats.dto.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class ChampionGlobalStatsDTO {
+  ChampionGlobalStatsDTO({
+    this.championName,
+    this.gamesPlayed,
+    this.wins,
+    this.winRate,
+    this.bestBuild,
+    this.bestRunes,
+    this.bestSpells,
+    this.bestSkillOrder,
+    this.roles,
+  });
+
+  String? championName;
+  int? gamesPlayed;
+  int? wins;
+  double? winRate;
+  BuildDTO? bestBuild;
+  RunesDTO? bestRunes;
+  SummonerSpellsDTO? bestSpells;
+  List<int>? bestSkillOrder;
+  List<RoleStatsDTO>? roles;
+
+  factory ChampionGlobalStatsDTO.fromJson(Map<String, dynamic> json) =>
+      _$ChampionGlobalStatsDTOFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ChampionGlobalStatsDTOToJson(this);
+}

--- a/lib/models/champion_global_stats.dto.g.dart
+++ b/lib/models/champion_global_stats.dto.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'champion_global_stats.dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ChampionGlobalStatsDTO _$ChampionGlobalStatsDTOFromJson(Map<String, dynamic> json) =>
+    ChampionGlobalStatsDTO(
+      championName: json['championName'] as String?,
+      gamesPlayed: (json['gamesPlayed'] as num?)?.toInt(),
+      wins: (json['wins'] as num?)?.toInt(),
+      winRate: (json['winRate'] as num?)?.toDouble(),
+      bestBuild: json['bestBuild'] == null
+          ? null
+          : BuildDTO.fromJson(json['bestBuild'] as Map<String, dynamic>),
+      bestRunes: json['bestRunes'] == null
+          ? null
+          : RunesDTO.fromJson(json['bestRunes'] as Map<String, dynamic>),
+      bestSpells: json['bestSpells'] == null
+          ? null
+          : SummonerSpellsDTO.fromJson(json['bestSpells'] as Map<String, dynamic>),
+      bestSkillOrder: (json['bestSkillOrder'] as List<dynamic>?)?.map((e) => e as int).toList(),
+      roles: (json['roles'] as List<dynamic>?)
+          ?.map((e) => RoleStatsDTO.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChampionGlobalStatsDTOToJson(ChampionGlobalStatsDTO instance) => <String, dynamic>{
+      'championName': instance.championName,
+      'gamesPlayed': instance.gamesPlayed,
+      'wins': instance.wins,
+      'winRate': instance.winRate,
+      'bestBuild': instance.bestBuild?.toJson(),
+      'bestRunes': instance.bestRunes?.toJson(),
+      'bestSpells': instance.bestSpells?.toJson(),
+      'bestSkillOrder': instance.bestSkillOrder,
+      'roles': instance.roles?.map((e) => e.toJson()).toList(),
+    };

--- a/lib/services/riot_api_service.dart
+++ b/lib/services/riot_api_service.dart
@@ -6,6 +6,7 @@ import 'package:wpgg/models/player_rank.dto.dart';
 import 'package:wpgg/models/stats.dto.dart';
 import 'package:wpgg/models/gameplay_recommendation.dto.dart';
 import 'package:wpgg/models/champion_detailed_stats.dto.dart';
+import 'package:wpgg/models/champion_global_stats.dto.dart';
 import '../app/app.locator.dart';
 import 'backend_api_service.dart';
 import 'secure_storage_service.dart';
@@ -144,6 +145,22 @@ class RiotApiService {
 
     await _secure.writeJson(cacheKey, data);
     return ChampionDetailedStatsDTO.fromJson(data);
+  }
+
+  // ---------- Champion Global Stats ------------------------------------
+  Future<ChampionGlobalStatsDTO> fetchChampionGlobalStats(String championName) async {
+    final cacheKey = 'champion_global_$championName';
+
+    final cached = await _secure.readJson(cacheKey);
+    if (cached != null) {
+      return ChampionGlobalStatsDTO.fromJson(cached as Map<String, dynamic>);
+    }
+
+    final data = await _api.get('$_base/champion-global/$championName')
+        as Map<String, dynamic>;
+
+    await _secure.writeJson(cacheKey, data);
+    return ChampionGlobalStatsDTO.fromJson(data);
   }
 
   // ---------- Gemini Recommendation ---------------------------------------

--- a/lib/ui/views/champion/champion_view.dart
+++ b/lib/ui/views/champion/champion_view.dart
@@ -118,6 +118,45 @@ class ChampionView extends StackedView<ChampionViewModel> {
                           ],
                         ),
                       ),
+                    if (viewModel.stats!.bestSpells != null)
+                      WpggCard(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            ...[
+                              viewModel.stats!.bestSpells!.summoner1Id,
+                              viewModel.stats!.bestSpells!.summoner2Id,
+                            ].whereType<int>().map(
+                              (id) => Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 2),
+                                child: Image.network(
+                                  ddragon.summonerSpellIcon(id)!,
+                                  width: 32,
+                                  height: 32,
+                                  errorBuilder: (_, __, ___) => const SizedBox(width: 32, height: 32),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    if (viewModel.stats!.bestSkillOrder != null &&
+                        viewModel.stats!.bestSkillOrder!.isNotEmpty)
+                      WpggCard(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(viewModel.stats!.bestSkillOrder!
+                                .map((e) => _slotToLetter(e))
+                                .join(' > ')),
+                          ],
+                        ),
+                      ),
+                    if (viewModel.stats!.roles != null)
+                      ...viewModel.stats!.roles!.map((r) => WpggCard(
+                            child: Text(
+                                '${r.role}: ${r.gamesPlayed} games - ${r.winRate?.toStringAsFixed(1) ?? '-'}% WR'),
+                          )),
                   ],
                 ],
               ),
@@ -131,4 +170,19 @@ class ChampionView extends StackedView<ChampionViewModel> {
 
   @override
   void onViewModelReady(ChampionViewModel viewModel) => viewModel.loadData();
+
+  String _slotToLetter(int slot) {
+    switch (slot) {
+      case 1:
+        return 'Q';
+      case 2:
+        return 'W';
+      case 3:
+        return 'E';
+      case 4:
+        return 'R';
+      default:
+        return slot.toString();
+    }
+  }
 }

--- a/lib/ui/views/champion/champion_viewmodel.dart
+++ b/lib/ui/views/champion/champion_viewmodel.dart
@@ -1,26 +1,21 @@
 import 'package:stacked/stacked.dart';
 import 'package:wpgg/app/app.locator.dart';
-import 'package:wpgg/models/champion_detailed_stats.dto.dart';
+import 'package:wpgg/models/champion_global_stats.dto.dart';
 import 'package:wpgg/services/riot_api_service.dart';
-import 'package:wpgg/services/secure_storage_service.dart';
 
 class ChampionViewModel extends BaseViewModel {
   final _riot = locator<RiotApiService>();
-  final _secure = locator<SecureStorageService>();
 
   final String championName;
   ChampionViewModel(this.championName);
 
-  ChampionDetailedStatsDTO? stats;
+  ChampionGlobalStatsDTO? stats;
 
   Future<void> loadData() async {
     setBusy(true);
     try {
-      final puuid = await _secure.read('last_puuid');
-      if (puuid != null) {
-        stats = await _riot.fetchChampionStats(puuid, championName);
-        notifyListeners();
-      }
+      stats = await _riot.fetchChampionGlobalStats(championName);
+      notifyListeners();
     } finally {
       setBusy(false);
     }

--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -49,7 +49,7 @@ class HomeView extends StackedView<HomeViewModel> {
                             decoration: InputDecoration(
                               filled: true,
                               fillColor: Theme.of(context).cardColor,
-                              hintText: 'Game name',
+                          hintText: 'Game name or Champion',
                               border: OutlineInputBorder(
                                 borderRadius: BorderRadius.circular(8),
                                 borderSide: BorderSide.none,
@@ -83,22 +83,6 @@ class HomeView extends StackedView<HomeViewModel> {
                         foregroundColor: Colors.white,
                       ),
                       child: const Text('Search'),
-                    ),
-                    const SizedBox(height: 16),
-                    SizedBox(
-                      width: 200,
-                      child: TextField(
-                        controller: viewModel.championController,
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: Theme.of(context).cardColor,
-                          hintText: 'Champion',
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide.none,
-                          ),
-                        ),
-                      ),
                     ),
                     const SizedBox(height: 16),
                     ElevatedButton(

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -10,7 +10,6 @@ import 'package:wpgg/ui/common/widgets/snackbar_bar.dart';
 class HomeViewModel extends BaseViewModel {
   final gameController = TextEditingController();
   final tagController = TextEditingController();
-  final championController = TextEditingController();
 
   final RiotApiService _riot = locator<RiotApiService>();
   final NavigationService _nav = locator<NavigationService>();
@@ -51,16 +50,8 @@ class HomeViewModel extends BaseViewModel {
   Future<void> searchChampion() async {
     setBusy(true);
     try {
-      final puuid = await _secure.read('last_puuid');
-      if (puuid == null) {
-        _snackbar.showCustomSnackBar(
-          variant: SnackbarType.error,
-          message: 'No summoner selected',
-        );
-        return;
-      }
       await _nav.navigateToChampionView(
-        championName: championController.text,
+        championName: gameController.text,
       );
     } finally {
       setBusy(false);
@@ -71,7 +62,6 @@ class HomeViewModel extends BaseViewModel {
   void dispose() {
     gameController.dispose();
     tagController.dispose();
-    championController.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- add `ChampionGlobalStatsDTO` model and serializer
- allow searching champion global stats via `RiotApiService`
- refactor champion view to display global data
- simplify champion search on home page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687007d2a518832cb19bb9d538136f41